### PR TITLE
add run_simulator script

### DIFF
--- a/run_simulator.sh
+++ b/run_simulator.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+if [ -z "$1" ]; then
+	echo "usage: sudo $0 <IMAGE>"
+	exit 1
+fi
+cd eVSSIM/QEMU/hw
+[ -d data ] || mkdir data
+[ -z "$(mount -l | grep 'hw/data')" ] && mount -t tmpfs -o size=16g tmpfs ./data
+cd data
+[ -e ssd.conf ] || ln -s ../../../CONFIG/ssd.conf
+cd ..
+../x86_64-softmmu/qemu-system-x86_64 -m 2048 -smp 4 -hda "$1" -device nvme -enable-kvm -redir tcp:2222::22


### PR DESCRIPTION
which create the temp dir, mount it and run the simulator automatically.
- The script receives the path to image as a parameter.
- The script needs root permissions in order to mount the tmpfs.
